### PR TITLE
Added stream_key parameter to the select_schema

### DIFF
--- a/integrations_testing_framework/utils.py
+++ b/integrations_testing_framework/utils.py
@@ -1,5 +1,6 @@
 import json
 
+
 def assert_matching_file_contents(file_1, file_2):
     i = 0
     for line in file_1:
@@ -14,13 +15,14 @@ def assert_matching_file_contents(file_1, file_2):
         raise Exception("File is empty.")
 
         
-def select_schema(catalog_path: str, stream_name: str) -> str:
+def select_schema(catalog_path: str, stream_name: str, stream_key: str = 'name') -> str:
     """
     Creates a catalog file with the stream_name selected.
     Example: @with_sys_args(['--config', config_path, '--catalog', utils.select_schema('all-streams.json', 'epics')])
 
     :param str catalog_path: a path of a catalog
     :param str stream_name: the name of the stream to be modified
+    :param str stream_key: the key that is using for stream dict to select the desired stream
     :return: the path of the catalog created as string
     :rtype: str
     """
@@ -31,7 +33,7 @@ def select_schema(catalog_path: str, stream_name: str) -> str:
     catalog = json.loads(catalog)
 
     for stream in catalog['streams']:
-        if stream['name'] == stream_name:
+        if stream[stream_key] == stream_name:
             stream['metadata'][0]['metadata']['selected'] = True
 
     # Open the file for writing.


### PR DESCRIPTION
Added stream_key parameter to the select_schema in order to get the schema from custom keys.

Default value for that parameter is "name" so there's nothing else need to be change in current tests and documents.